### PR TITLE
ignoring yarn lockfile

### DIFF
--- a/code/node-server/.gitignore
+++ b/code/node-server/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 package-lock.json
 node_modules
+yarn.lock


### PR DESCRIPTION
In the event we have people using yarn over npm, let's not forget to ignore the `yarn.lock` file