### PR TITLE
command line arg for total group count for npm start

### DIFF
--- a/code/node-server/README.md
+++ b/code/node-server/README.md
@@ -2,3 +2,4 @@
 
 - [Debugging Node Applications](https://medium.com/the-node-js-collection/debugging-node-js-with-google-chrome-4965b5f910f4)
 - Run `npm i && npm run watch` to start a hot reloading server that also connects to your chrome console
+- The server accepts an _optional_ command line argument that will set the total number of groups. This only works with `npm start`: `npm start -- --groups=50`. Note that you need to add `--` before the groups arg. [See this StackOverflow Post for more information](https://stackoverflow.com/questions/11580961/sending-command-line-arguments-to-npm-script)

--- a/code/node-server/config.js
+++ b/code/node-server/config.js
@@ -1,10 +1,11 @@
 // hard coding how identicons are done right now for a 500x500 board
+const argv = require('yargs').argv // use yargs to parse command line args to set num groups
 module.exports = {
   ROWS: 100,
   COLUMNS: 100,
   HTTPPORT: 3000,
   WSPORT: 8080,
-  IDLIMIT: {low: 0, high: 25},
+  IDLIMIT: { low: 0, high: argv.groups ? argv.groups : 40 },
   LIMITWINDOW: 1000,
   LIMITCOUNT: 5,
   ADMIN_SECRET: '0' // TODO: make secret, add to .gitignore

--- a/code/node-server/index.js
+++ b/code/node-server/index.js
@@ -33,6 +33,7 @@ app.use((req, res, next) => {
 })
 
 app.post('/tile', (req, res) => { // /tile?x=x&y=y&c=c&id=ID
+  debugger
   const tile = {
     x: parseInt(req.query.x),
     y: parseInt(req.query.y),
@@ -79,3 +80,4 @@ app.use((err, req, res, next) => {
 
 //*********************************** START! ***********************************
 app.listen(config.HTTPPORT, () => console.log(`App listening on port ${config.HTTPPORT}!`))
+console.log(config)

--- a/code/node-server/index.js
+++ b/code/node-server/index.js
@@ -33,7 +33,6 @@ app.use((req, res, next) => {
 })
 
 app.post('/tile', (req, res) => { // /tile?x=x&y=y&c=c&id=ID
-  debugger
   const tile = {
     x: parseInt(req.query.x),
     y: parseInt(req.query.y),


### PR DESCRIPTION
Allows us to start up the app with an optional group count. Only works for `npm start` as supervisor does not like this extra flag; `npm start -- --groups=90`

