### PR TITLE
add ability to track number of errors and error types

### DIFF
--- a/code/browser-canvas-client/HTTPConn.js
+++ b/code/browser-canvas-client/HTTPConn.js
@@ -1,9 +1,9 @@
 class HTTPConn {
-  
+
   constructor(endpoint) {
     this.endpoint = endpoint
   }
-  
+
   getBoard() {
     const route = `/board?id=${config.ID}`
     fetch(this.endpoint + route, { method: 'GET' })

--- a/code/node-server/src/app/achievements.js
+++ b/code/node-server/src/app/achievements.js
@@ -2,26 +2,58 @@ class Achievements {
   constructor(groupId) {
     this.groupId = groupId
     this.mileStones = {
-      '1': false,
-      '100': false,
-      '500': false,
-      '1000': false,
-      '5000': false,
-      '10000': false,
-      '20000': false,
-      '30000': false,
-      '40000': false,
-      '50000': false
+      'writes': {
+        '1': false,
+        '100': false,
+        '500': false,
+        '1000': false,
+        '5000': false,
+        '10000': false,
+        '20000': false,
+        '30000': false,
+        '40000': false,
+        '50000': false
+      },
+
+      'errors': {
+        '1': false,
+        '10': false,
+        '50': false,
+        '100': false,
+        '500': false,
+        '1000': false
+      },
+
+      'errorTypes': {
+        'invalidTile': false,
+        'invalidColor': false,
+        'invalidID': false
+      }
     }
   }
 
-  addMilestone(numWrites) {
-    if (this.mileStones[numWrites] !== undefined) this.mileStones[numWrites] = true
+  addMilestone(type, num) {
+    if (this.mileStones[type][num] !== undefined) this.mileStones[type][num] = true
+  }
+
+  addErrorTypeMilestone(errorType) {
+    if (this.mileStones['errorTypes'][errorType] !== undefined) this.mileStones['errorTypes'][errorType] = true
   }
 
   stringifyAchievements() {
-    const mileStones = Object.keys(this.mileStones).filter(k => this.mileStones[k])
-    return `congratulations on the following achievements: ${mileStones.join(', ')} writes!`
+    const writes = Object.keys(this.mileStones['writes']).filter(k => this.mileStones['writes'][k])
+    const errors = Object.keys(this.mileStones['errors']).filter(k => this.mileStones['errors'][k])
+    const errorTypes = Object.keys(this.mileStones['errorTypes']).filter(k => this.mileStones['errorTypes'][k])
+    const stringifiedTypes = errorTypes.map(e => e.toLowerCase().split('invalid').join('invalid ')) // e.g. changes 'invalidTile' to 'invalid tile'
+
+    if (writes.length > 0 || errors.length > 0 || errorTypes.length > 0) {
+      return `Congratulations on the following achievements: \n
+      ${writes.length > 0 ? `${writes.join(', ')} write(s)` : ''} \n
+      ${errors.length > 0 ? `${errors.join(', ')} error(s). \n
+      Type(s) of errors achieved: ${stringifiedTypes.join(', ')}` : ''}`
+    } else {
+      return 'No achievements yet'
+    }
   }
 }
 

--- a/code/node-server/src/app/group.js
+++ b/code/node-server/src/app/group.js
@@ -6,23 +6,31 @@ class Group {
     Group.all[groupId].addWrite()
   }
 
+  static addError(errorType, groupId) {
+    Group.all[groupId].addError(errorType)
+  }
+
   constructor(id) {
     this.id = id
     this.writes = 0
     this.errors = 0
+    this.errorTypes = []
     this.achievements = new Achievements(this.id)
     Group.all[this.id] = this
   }
 
   addWrite() {
     this.writes++
-    this.achievements.addMilestone(this.writes)
+    this.achievements.addMilestone('writes', this.writes)
     // if (this.writes % 100 === 0) this.achievements.add(`Writes: ${this.writes}`)
   }
 
-  addError() {
+  addError(errorType) {
     this.errors++
-    if (this.errors % 100 === 0) this.achievements.add(`Errors: ${this.writes}`)
+    this.errorTypes.push(errorType)
+    this.achievements.addMilestone('errors', this.errors)
+    this.achievements.addErrorTypeMilestone(errorType)
+    // if (this.errors % 100 === 0) this.achievements.add(`Errors: ${this.writes}`)
   }
 
   toJSON() {
@@ -30,6 +38,7 @@ class Group {
       id: this.id,
       writes: this.writes,
       errors: this.errors,
+      errorTypes: this.errorTypes,
       achievements: this.achievements.stringifyAchievements()
     }
   }

--- a/code/node-server/src/middleware/validator.js
+++ b/code/node-server/src/middleware/validator.js
@@ -2,6 +2,7 @@ const config = require('../../config.js')
 const validID = require('./reqValidators/validID.js')
 const validColor = require('./reqValidators/validColor.js')
 const validTile = require('./reqValidators/validTile.js')
+const Group = require('../app/group.js')
 
 /* this is strictly for validating routes that have specific parameter
  * requirements. If a request url isn't present here, it doesn't mean 404
@@ -23,8 +24,12 @@ const routeValidators = {
 
 function validRequest(req, res, next) {
   const validators = routeValidators[req.method][req.path]
-  if (!validators.every(validator => validator(req)))
+  if (!validators.every(validator => validator(req))) {
+    const invalids = validators.filter(validator => !validator(req)) // finds the validation methods that failed
+    const groupId = req.query.id
+    invalids.forEach(invalid => Group.addError(`in${invalid.name}`, groupId)) // passes name of validation method failed and changes it from e.g. "validTile" to "invalidTile"
     return res.status(422).send('Bad Request! Check your id, coordinates, color value, etc.')
+  }
   next()
 }
 


### PR DESCRIPTION
Addresses issue #20 - add number of errors (similar to numWrites) as well as error type (e.g. invalid tile/color/id) using the check in Validator.js

- Pushes all error types into a group's error type array (not sure if we should .uniq this, may be interesting to count how many times a group has placed an invalid tile/etc?)
- Add separate keys in Achievement's milestones hash for errors and errorTypes - should we count the number of error types/increase the achievement numbers for errors?
- Altered stringifyAchievements() to reflect changes
- Are there any other areas that we should be checking for errors?

Thanks!