### PR TITLE
fix group id validation issues causing server to EXPLODE

### DIFF
--- a/code/node-server/src/middleware/reqValidators/validID.js
+++ b/code/node-server/src/middleware/reqValidators/validID.js
@@ -1,8 +1,8 @@
 const config = require('../../../config.js')
 
 function validID(req) {
-  const id = req.query.id
-  return id <= config.IDLIMIT['low'] || id >= config.IDLIMIT['high'] ? true : false
+  const id = parseInt(req.query.id)
+  return id < config.IDLIMIT['low'] || id > config.IDLIMIT['high'] ? false : true
 }
 
 module.exports = validID


### PR DESCRIPTION
Fixed issue where `validID.js` is causing any id aside from 0 to blow up the server. Fixed it